### PR TITLE
Implement support for icons.

### DIFF
--- a/Inspector/Inspector.xcodeproj/project.pbxproj
+++ b/Inspector/Inspector.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		9184AC022825741600227C3A /* ScreenContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9184AC012825741600227C3A /* ScreenContent.swift */; };
 		91B2EA9928CA05B900A90A83 /* Compound in Frameworks */ = {isa = PBXBuildFile; productRef = 91B2EA9828CA05B900A90A83 /* Compound */; };
 		91B2EA9C28CA064800A90A83 /* ColorsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B2EA9B28CA064800A90A83 /* ColorsScreen.swift */; };
+		91B946812A29062300F187EF /* IconsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B946802A29062300F187EF /* IconsScreen.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -47,6 +48,7 @@
 		91AB476A2A0E774E00D961AE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		91B2EA9728CA048200A90A83 /* compound-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "compound-ios"; path = ..; sourceTree = "<group>"; };
 		91B2EA9B28CA064800A90A83 /* ColorsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorsScreen.swift; sourceTree = "<group>"; };
+		91B946802A29062300F187EF /* IconsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconsScreen.swift; sourceTree = "<group>"; };
 		9F9AF07976782861ECA2764C /* Pods-Compound Inspector.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Compound Inspector.release.xcconfig"; path = "Target Support Files/Pods-Compound Inspector/Pods-Compound Inspector.release.xcconfig"; sourceTree = "<group>"; };
 		B62609A3377EA1D9C59FCD20 /* Pods-Compound Inspector.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Compound Inspector.debug.xcconfig"; path = "Target Support Files/Pods-Compound Inspector/Pods-Compound Inspector.debug.xcconfig"; sourceTree = "<group>"; };
 		D2E28F45EEA9A8DE6AFB10E9 /* Pods_Compound_Inspector.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Compound_Inspector.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -90,6 +92,7 @@
 				917C22F529C37A9D00B35660 /* AllCases.swift */,
 				91B2EA9B28CA064800A90A83 /* ColorsScreen.swift */,
 				917C22F729C380A200B35660 /* FontsScreen.swift */,
+				91B946802A29062300F187EF /* IconsScreen.swift */,
 			);
 			path = Tokens;
 			sourceTree = "<group>";
@@ -263,6 +266,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				91B946812A29062300F187EF /* IconsScreen.swift in Sources */,
 				917F562F28256DD800D19543 /* SidebarList.swift in Sources */,
 				917C22F629C37A9D00B35660 /* AllCases.swift in Sources */,
 				917F561C28256DB800D19543 /* CompoundInspectorApp.swift in Sources */,

--- a/Inspector/Inspector.xcodeproj/project.pbxproj
+++ b/Inspector/Inspector.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		917F562028256DB900D19543 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 917F561F28256DB900D19543 /* Assets.xcassets */; };
 		917F562F28256DD800D19543 /* SidebarList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917F562E28256DD800D19543 /* SidebarList.swift */; };
 		9184AC022825741600227C3A /* ScreenContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9184AC012825741600227C3A /* ScreenContent.swift */; };
+		9188246A2A2DE882001606AE /* Screen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918824692A2DE882001606AE /* Screen.swift */; };
 		91B2EA9928CA05B900A90A83 /* Compound in Frameworks */ = {isa = PBXBuildFile; productRef = 91B2EA9828CA05B900A90A83 /* Compound */; };
 		91B2EA9C28CA064800A90A83 /* ColorsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B2EA9B28CA064800A90A83 /* ColorsScreen.swift */; };
 		91B946812A29062300F187EF /* IconsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B946802A29062300F187EF /* IconsScreen.swift */; };
@@ -45,6 +46,7 @@
 		917F562E28256DD800D19543 /* SidebarList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SidebarList.swift; sourceTree = "<group>"; };
 		917F563028256DDC00D19543 /* TextFieldsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldsScreen.swift; sourceTree = "<group>"; };
 		9184AC012825741600227C3A /* ScreenContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenContent.swift; sourceTree = "<group>"; };
+		918824692A2DE882001606AE /* Screen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Screen.swift; sourceTree = "<group>"; };
 		91AB476A2A0E774E00D961AE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		91B2EA9728CA048200A90A83 /* compound-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "compound-ios"; path = ..; sourceTree = "<group>"; };
 		91B2EA9B28CA064800A90A83 /* ColorsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorsScreen.swift; sourceTree = "<group>"; };
@@ -122,6 +124,7 @@
 			children = (
 				917F561B28256DB800D19543 /* CompoundInspectorApp.swift */,
 				917F562E28256DD800D19543 /* SidebarList.swift */,
+				918824692A2DE882001606AE /* Screen.swift */,
 				9184AC012825741600227C3A /* ScreenContent.swift */,
 				9145A25128CCAD08001B3451 /* Tokens */,
 				91B2EA9A28CA05F300A90A83 /* Components */,
@@ -271,6 +274,7 @@
 				917C22F629C37A9D00B35660 /* AllCases.swift in Sources */,
 				917F561C28256DB800D19543 /* CompoundInspectorApp.swift in Sources */,
 				917C22F829C380A200B35660 /* FontsScreen.swift in Sources */,
+				9188246A2A2DE882001606AE /* Screen.swift in Sources */,
 				9184AC022825741600227C3A /* ScreenContent.swift in Sources */,
 				917C22F429C3760A00B35660 /* FormScreen.swift in Sources */,
 				91B2EA9C28CA064800A90A83 /* ColorsScreen.swift in Sources */,

--- a/Inspector/Inspector.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Inspector/Inspector.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,7 +5,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vector-im/compound-design-tokens.git",
       "state" : {
-        "revision" : "d9d1a792d8a124708c7e15becd359893ee9e9ea6"
+        "revision" : "cc950d575f8536ff5bebbd02e28c0b8ab541aa29"
       }
     },
     {

--- a/Inspector/Sources/Components/FormScreen.swift
+++ b/Inspector/Sources/Components/FormScreen.swift
@@ -34,12 +34,6 @@ struct FormScreen: View {
         }
         .compoundForm()
         .navigationTitle("Forms")
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            Button(action: HyperionManager.sharedInstance().togglePluginDrawer) {
-                Image(systemName: "ruler")
-            }
-        }
     }
     
     @ViewBuilder

--- a/Inspector/Sources/CompoundInspectorApp.swift
+++ b/Inspector/Sources/CompoundInspectorApp.swift
@@ -12,6 +12,7 @@ import HyperionCore
 @main
 struct CompoundInspectorApp: App {
     @State private var colorScheme: ColorScheme = .light
+    @State private var dynamicTypeSize: DynamicTypeSize = .large
     
     private var isDark: Bool { colorScheme == .dark }
     
@@ -20,11 +21,17 @@ struct CompoundInspectorApp: App {
             NavigationSplitView {
                 SidebarList()
                     .navigationTitle("Components")
+                    #if targetEnvironment(macCatalyst)
+                    .dynamicTypeSize(.large)
+                    #endif
             } detail: {
                 EmptyView()
             }
             .accentColor(.compound.textActionPrimary)
             .preferredColorScheme(colorScheme)
+            #if targetEnvironment(macCatalyst)
+            .dynamicTypeSize(dynamicTypeSize)
+            #endif
         }
         .commands {
             CommandMenu("Options") {
@@ -35,6 +42,14 @@ struct CompoundInspectorApp: App {
                 
                 Button("Toggle Appearance", action: toggleDarkMode)
                     .keyboardShortcut("a", modifiers: [.command, .shift])
+                
+                #if targetEnvironment(macCatalyst)
+                Picker("Text Size", selection: $dynamicTypeSize) {
+                    ForEach(DynamicTypeSize.allCases, id: \.self) { size in
+                        Text(String(describing: size)).tag(size)
+                    }
+                }
+                #endif
             }
         }
     }

--- a/Inspector/Sources/CompoundInspectorApp.swift
+++ b/Inspector/Sources/CompoundInspectorApp.swift
@@ -21,17 +21,19 @@ struct CompoundInspectorApp: App {
             NavigationSplitView {
                 SidebarList()
                     .navigationTitle("Components")
-                    #if targetEnvironment(macCatalyst)
-                    .dynamicTypeSize(.large)
-                    #endif
+                    .navigationDestination(for: Screen.self) { screen in
+                        screen
+                            #if targetEnvironment(macCatalyst)
+                            .dynamicTypeSize(dynamicTypeSize)
+                            #endif
+                            .navigationBarTitleDisplayMode(.inline)
+                            .toolbar { screenToolbar }
+                    }
             } detail: {
                 EmptyView()
             }
             .accentColor(.compound.textActionPrimary)
             .preferredColorScheme(colorScheme)
-            #if targetEnvironment(macCatalyst)
-            .dynamicTypeSize(dynamicTypeSize)
-            #endif
         }
         .commands {
             CommandMenu("Options") {
@@ -44,13 +46,33 @@ struct CompoundInspectorApp: App {
                     .keyboardShortcut("a", modifiers: [.command, .shift])
                 
                 #if targetEnvironment(macCatalyst)
-                Picker("Text Size", selection: $dynamicTypeSize) {
-                    ForEach(DynamicTypeSize.allCases, id: \.self) { size in
-                        Text(String(describing: size)).tag(size)
-                    }
-                }
+                textSizePicker
                 #endif
             }
+        }
+    }
+    
+    var textSizePicker: some View {
+        Picker("Text Size", selection: $dynamicTypeSize) {
+            ForEach(DynamicTypeSize.allCases, id: \.self) { size in
+                Text(String(describing: size)).tag(size)
+            }
+        }
+    }
+    
+    @ViewBuilder
+    var screenToolbar: some View {
+        #if targetEnvironment(macCatalyst)
+        Menu {
+            textSizePicker
+                .pickerStyle(.inline)
+        } label: {
+            Image(systemName: "textformat.size")
+        }
+        #endif
+
+        Button(action: HyperionManager.sharedInstance().togglePluginDrawer) {
+            Image(systemName: "ruler")
         }
     }
     

--- a/Inspector/Sources/Screen.swift
+++ b/Inspector/Sources/Screen.swift
@@ -1,0 +1,42 @@
+//
+//  Screen.swift
+//  Compound Inspector
+//
+//  Created by Doug on 05/06/2023.
+//
+
+import SwiftUI
+
+/// A screen of components/tokens that can be navigated to.
+enum Screen: Hashable, View {
+    /// Color tokens
+    case colors
+    /// Font tokens
+    case fonts
+    /// Icon tokens
+    case icons
+    /// Size tokens
+    case sizes
+    
+    /// Form styles and components
+    case form
+    /// Label styles
+    case labels
+    /// Button styles
+    case buttons
+    /// Text field styles.
+    case textFields
+    
+    var body: some View {
+        switch self {
+        case .colors: ColorsScreen()
+        case .fonts: FontsScreen()
+        case .icons: IconsScreen()
+        case .form: FormScreen()
+        case .sizes: EmptyView()
+        case .labels: EmptyView()
+        case .buttons: EmptyView()
+        case .textFields: EmptyView()
+        }
+    }
+}

--- a/Inspector/Sources/ScreenContent.swift
+++ b/Inspector/Sources/ScreenContent.swift
@@ -6,8 +6,8 @@
 //
 
 import SwiftUI
-import HyperionCore
 
+/// A helper to provider a default layout for the content of a screen.
 struct ScreenContent<Content: View>: View {
     let navigationTitle: String
     @ViewBuilder var content: () -> Content
@@ -20,12 +20,6 @@ struct ScreenContent<Content: View>: View {
             .padding()
         }
         .navigationTitle(navigationTitle)
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            Button(action: HyperionManager.sharedInstance().togglePluginDrawer) {
-                Image(systemName: "ruler")
-            }
-        }
     }
 }
 

--- a/Inspector/Sources/SidebarList.swift
+++ b/Inspector/Sources/SidebarList.swift
@@ -26,6 +26,9 @@ struct SidebarList: View {
             NavigationLink(destination: FontsScreen.init) {
                 Label("Typography", systemImage: "character")
             }
+            NavigationLink(destination: IconsScreen.init) {
+                Label("Icons", systemImage: "pencil.and.outline")
+            }
             NavigationLink(destination: ColorsScreen.init) {
                 Label("Sizes", systemImage: "ruler")
             }
@@ -40,6 +43,10 @@ struct SidebarList: View {
             }
             NavigationLink(destination: ColorsScreen.init) {
                 Label("Labels", systemImage: "character.textbox")
+            }
+            .disabled(true)
+            NavigationLink(destination: ColorsScreen.init) {
+                Label("Buttons", systemImage: "rectangle.and.hand.point.up.left")
             }
             .disabled(true)
             NavigationLink(destination: ColorsScreen.init) {

--- a/Inspector/Sources/SidebarList.swift
+++ b/Inspector/Sources/SidebarList.swift
@@ -20,16 +20,16 @@ struct SidebarList: View {
     
     var tokensSection: some View {
         Section("Tokens") {
-            NavigationLink(destination: ColorsScreen.init) {
+            NavigationLink(value: Screen.colors) {
                 Label("Colours", systemImage: "paintpalette")
             }
-            NavigationLink(destination: FontsScreen.init) {
+            NavigationLink(value: Screen.fonts) {
                 Label("Typography", systemImage: "character")
             }
-            NavigationLink(destination: IconsScreen.init) {
+            NavigationLink(value: Screen.icons) {
                 Label("Icons", systemImage: "pencil.and.outline")
             }
-            NavigationLink(destination: ColorsScreen.init) {
+            NavigationLink(value: Screen.sizes) {
                 Label("Sizes", systemImage: "ruler")
             }
             .disabled(true)
@@ -38,18 +38,18 @@ struct SidebarList: View {
     
     var componentsSection: some View {
         Section("Components") {
-            NavigationLink(destination: FormScreen.init) {
+            NavigationLink(value: Screen.form) {
                 Label("Form", systemImage: "list.bullet.clipboard")
             }
-            NavigationLink(destination: ColorsScreen.init) {
+            NavigationLink(value: Screen.labels) {
                 Label("Labels", systemImage: "character.textbox")
             }
             .disabled(true)
-            NavigationLink(destination: ColorsScreen.init) {
+            NavigationLink(value: Screen.buttons) {
                 Label("Buttons", systemImage: "rectangle.and.hand.point.up.left")
             }
             .disabled(true)
-            NavigationLink(destination: ColorsScreen.init) {
+            NavigationLink(value: Screen.textFields) {
                 Label("Text Fields", systemImage: "character.cursor.ibeam")
             }
             .disabled(true)

--- a/Inspector/Sources/Tokens/AllCases.swift
+++ b/Inspector/Sources/Tokens/AllCases.swift
@@ -37,3 +37,41 @@ extension CompoundFonts {
         return fonts
     }
 }
+
+extension CompoundIcons {
+    var allIcons: [(name: String, value: Image)] {
+        var icons: [(name: String, value: Image)] = []
+        let mirror = Mirror(reflecting: self)
+        
+        for property in mirror.children {
+            if let label = property.label, let icon = property.value as? Image {
+                icons.append((label, icon))
+            }
+        }
+        
+        return icons
+    }
+    
+    var allKeyPaths: [(name: String, value: KeyPath<Self, Image>)] {
+        var icons: [(name: String, value: KeyPath<Self, Image>)] = []
+        let mirror = Mirror(reflecting: self)
+        
+        for property in mirror.children {
+            if let label = property.label {
+                let keyPath = \Self.[checkedMirrorDescendant: label] as PartialKeyPath
+                
+                if let imageKeyPath = keyPath as? KeyPath<Self, Image> {
+                    icons.append((label, imageKeyPath))
+                } else {
+                    print("Nope")
+                }
+            }
+        }
+        
+        return icons
+    }
+    
+    private subscript(checkedMirrorDescendant key: String) -> Any {
+        return Mirror(reflecting: self).descendant(key)!
+    }
+}

--- a/Inspector/Sources/Tokens/ColorsScreen.swift
+++ b/Inspector/Sources/Tokens/ColorsScreen.swift
@@ -28,8 +28,10 @@ struct ColorItem: View {
             
             VStack(alignment: .leading) {
                 Text(name)
+                    .font(.compound.bodyLG)
+                    .foregroundColor(.compound.textPrimary)
                 Text(color.hexValue())
-                    .font(.footnote.monospaced())
+                    .font(.compound.bodySM.monospaced())
                     .foregroundColor(.compound.textSecondary)
             }
         }
@@ -42,7 +44,7 @@ struct ColorItem: View {
             .aspectRatio(1, contentMode: .fit)
             .overlay {
                 swatchShape
-                    .strokeBorder(Color.compound.textPrimary, lineWidth: 1.5)
+                    .strokeBorder(Color.compound.iconPrimary, lineWidth: 1.5)
                     .opacity(0.2)
             }
     }

--- a/Inspector/Sources/Tokens/IconsScreen.swift
+++ b/Inspector/Sources/Tokens/IconsScreen.swift
@@ -1,0 +1,45 @@
+//
+//  IconsScreen.swift
+//  Compound Inspector
+//
+//  Created by Doug on 01/06/2023.
+//
+
+import SwiftUI
+import Compound
+
+struct IconsScreen: View {
+    var body: some View {
+        ScreenContent(navigationTitle: "Icons") {
+            ForEach(Image.compound.allIcons, id: \.name) { icon in
+                IconItem(icon: icon.value, name: icon.name)
+            }
+        }
+    }
+}
+
+struct IconItem: View {
+    let icon: Image
+    let name: String
+    
+    var body: some View {
+        Label {
+            Text(name)
+                .foregroundColor(.compound.textPrimary)
+        } icon: {
+            CompoundIcon(customImage: icon)
+                .foregroundColor(.compound.iconSecondary)
+        }
+        .font(.compound.bodyLG)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct IconsScreen_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            IconsScreen()
+        }
+        .previewLayout(.fixed(width: 375, height: 750))
+    }
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,7 +5,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vector-im/compound-design-tokens.git",
       "state" : {
-        "revision" : "d9d1a792d8a124708c7e15becd359893ee9e9ea6"
+        "revision" : "cc950d575f8536ff5bebbd02e28c0b8ab541aa29"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(name: "Compound", targets: ["Compound"])
     ],
     dependencies: [
-        .package(url: "https://github.com/vector-im/compound-design-tokens.git", revision: "d9d1a792d8a124708c7e15becd359893ee9e9ea6"),
+        .package(url: "https://github.com/vector-im/compound-design-tokens.git", revision: "cc950d575f8536ff5bebbd02e28c0b8ab541aa29"),
         .package(url: "https://github.com/siteline/SwiftUI-Introspect.git", from: "0.2.3")
     ],
     targets: [

--- a/Sources/Compound/Colors/CompoundColors.swift
+++ b/Sources/Compound/Colors/CompoundColors.swift
@@ -31,23 +31,60 @@ public struct CompoundColors {
     /// of dark and high contract variants the generated collections each contain the same token set.
     private static let compound = CompoundLightDesignTokens.self
     
+    public let iconOnSolidPrimary = compound.colorIconOnSolidPrimary
+    public let iconInfoPrimary = compound.colorIconInfoPrimary
+    public let iconSuccessPrimary = compound.colorIconSuccessPrimary
+    public let iconCriticalPrimary = compound.colorIconCriticalPrimary
     public let iconAccentTertiary = compound.colorIconAccentTertiary
+    public let iconQuaternaryAlpha = compound.colorIconQuaternaryAlpha
+    public let iconTertiaryAlpha = compound.colorIconTertiaryAlpha
+    public let iconSecondaryAlpha = compound.colorIconSecondaryAlpha
+    public let iconPrimaryAlpha = compound.colorIconPrimaryAlpha
+    public let iconDisabled = compound.colorIconDisabled
     public let iconQuaternary = compound.colorIconQuaternary
     public let iconTertiary = compound.colorIconTertiary
     public let iconSecondary = compound.colorIconSecondary
     public let iconPrimary = compound.colorIconPrimary
-    public let textLinkExternal = compound.colorTextLinkExternal
+    public let borderInfoSubtle = compound.colorBorderInfoSubtle
+    public let borderSuccessSubtle = compound.colorBorderSuccessSubtle
+    public let borderCriticalSubtle = compound.colorBorderCriticalSubtle
+    public let borderCriticalHovered = compound.colorBorderCriticalHovered
+    public let borderCriticalPrimary = compound.colorBorderCriticalPrimary
+    public let borderInteractiveHovered = compound.colorBorderInteractiveHovered
+    public let borderInteractiveSecondary = compound.colorBorderInteractiveSecondary
+    public let borderInteractivePrimary = compound.colorBorderInteractivePrimary
+    public let borderFocused = compound.colorBorderFocused
+    public let borderDisabled = compound.colorBorderDisabled
+    public let bgSubtleSecondaryLevel0 = compound.colorBgSubtleSecondaryLevel0
+    public let bgInfoSubtle = compound.colorBgInfoSubtle
+    public let bgSuccessSubtle = compound.colorBgSuccessSubtle
+    public let bgCriticalSubtleHovered = compound.colorBgCriticalSubtleHovered
+    public let bgCriticalSubtle = compound.colorBgCriticalSubtle
+    public let bgCriticalHovered = compound.colorBgCriticalHovered
+    public let bgCriticalPrimary = compound.colorBgCriticalPrimary
+    public let bgActionSecondaryPressed = compound.colorBgActionSecondaryPressed
+    public let bgActionSecondaryHovered = compound.colorBgActionSecondaryHovered
+    public let bgActionSecondaryRest = compound.colorBgActionSecondaryRest
+    public let bgActionPrimaryDisabled = compound.colorBgActionPrimaryDisabled
+    public let bgActionPrimaryPressed = compound.colorBgActionPrimaryPressed
+    public let bgActionPrimaryHovered = compound.colorBgActionPrimaryHovered
+    public let bgActionPrimaryRest = compound.colorBgActionPrimaryRest
+    public let bgCanvasDefaultLevel1 = compound.colorBgCanvasDefaultLevel1
+    public let bgCanvasDisabled = compound.colorBgCanvasDisabled
+    public let bgCanvasDefault = compound.colorBgCanvasDefault
+    public let bgSubtleSecondary = compound.colorBgSubtleSecondary
+    public let bgSubtlePrimary = compound.colorBgSubtlePrimary
+    public let textOnSolidPrimary = compound.colorTextOnSolidPrimary
+    public let textInfoPrimary = compound.colorTextInfoPrimary
+    public let textSuccessPrimary = compound.colorTextSuccessPrimary
     public let textCriticalPrimary = compound.colorTextCriticalPrimary
+    public let textLinkExternal = compound.colorTextLinkExternal
     public let textActionAccent = compound.colorTextActionAccent
     public let textActionPrimary = compound.colorTextActionPrimary
     public let textDisabled = compound.colorTextDisabled
     public let textPlaceholder = compound.colorTextPlaceholder
     public let textSecondary = compound.colorTextSecondary
     public let textPrimary = compound.colorTextPrimary
-    public let bgActionPrimaryRest = compound.colorBgActionPrimaryRest
-    public let bgSubtleSecondary = compound.colorBgSubtleSecondary
-    public let bgSubtlePrimary = compound.colorBgSubtlePrimary
-    public let bgCanvas = compound.colorBgCanvasDefault
     
     // MARK: - Core Colors
     

--- a/Sources/Compound/Fonts/FontSize.swift
+++ b/Sources/Compound/Fonts/FontSize.swift
@@ -1,12 +1,14 @@
 import SwiftUI
 
+/// The size of a SwiftUI font.
 enum FontSize {
-    case custom(CGFloat)
+    case custom(CGFloat, Font.TextStyle?)
     case style(Font.TextStyle)
     
+    /// The raw value in points.
     var value: CGFloat {
         switch self {
-        case .custom(let size):
+        case .custom(let size, _):
             return size
         case .style(let style):
             switch style {
@@ -36,10 +38,11 @@ enum FontSize {
         }
     }
     
+    /// The text style of the font.
     var style: Font.TextStyle {
         switch self {
-        case .custom:
-            return .body // this is a wrong assumption
+        case .custom(_, let textStyle):
+            return textStyle ?? .body
         case .style(let textStyle):
             return textStyle
         }
@@ -55,7 +58,7 @@ enum FontSize {
         let mirror = Mirror(reflecting: provider)
         
         if let size = mirror.descendant("size") as? CGFloat {
-            return .custom(size)
+            return .custom(size, mirror.descendant("textStyle") as? Font.TextStyle)
         } else if let textStyle = mirror.descendant("style") as? Font.TextStyle {
             return .style(textStyle)
         }

--- a/Sources/Compound/Fonts/FontSize.swift
+++ b/Sources/Compound/Fonts/FontSize.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+enum FontSize {
+    case custom(CGFloat)
+    case style(Font.TextStyle)
+    
+    var value: CGFloat {
+        switch self {
+        case .custom(let size):
+            return size
+        case .style(let style):
+            switch style {
+            case .largeTitle:
+                return 34
+            case .title:
+                return 28
+            case .title2:
+                return 22
+            case .title3:
+                return 20
+            case .subheadline:
+                return 15
+            case .body, .headline:
+                return 17
+            case .callout:
+                return 16
+            case .footnote:
+                return 13
+            case .caption:
+                return 12
+            case .caption2:
+                return 11
+            @unknown default:
+                return 17
+            }
+        }
+    }
+    
+    var style: Font.TextStyle {
+        switch self {
+        case .custom:
+            return .body // this is a wrong assumption
+        case .style(let textStyle):
+            return textStyle
+        }
+    }
+    
+    static func reflecting(_ font: Font) -> FontSize? {
+        let mirror = Mirror(reflecting: font)
+        guard let provider = mirror.descendant("provider", "base") else { return nil }
+        return resolveFontSize(provider)
+    }
+    
+    private static func resolveFontSize(_ provider: Any) -> FontSize? {
+        let mirror = Mirror(reflecting: provider)
+        
+        if let size = mirror.descendant("size") as? CGFloat {
+            return .custom(size)
+        } else if let textStyle = mirror.descendant("style") as? Font.TextStyle {
+            return .style(textStyle)
+        }
+        
+        // recurse to handle modifiers.
+        guard let provider = mirror.descendant("base", "provider", "base") else { return nil }
+        return resolveFontSize(provider)
+    }
+}

--- a/Sources/Compound/Fonts/FontSize.swift
+++ b/Sources/Compound/Fonts/FontSize.swift
@@ -13,27 +13,29 @@ enum FontSize {
         case .style(let style):
             switch style {
             case .largeTitle:
-                return 34
+                return UIFont.preferredFont(forTextStyle: .largeTitle).pointSize
             case .title:
-                return 28
+                return UIFont.preferredFont(forTextStyle: .title1).pointSize
             case .title2:
-                return 22
+                return UIFont.preferredFont(forTextStyle: .title2).pointSize
             case .title3:
-                return 20
-            case .subheadline:
-                return 15
-            case .body, .headline:
-                return 17
+                return UIFont.preferredFont(forTextStyle: .title3).pointSize
+            case .body:
+                return UIFont.preferredFont(forTextStyle: .body).pointSize
+            case .headline:
+                return UIFont.preferredFont(forTextStyle: .headline).pointSize
             case .callout:
-                return 16
+                return UIFont.preferredFont(forTextStyle: .callout).pointSize
+            case .subheadline:
+                return UIFont.preferredFont(forTextStyle: .subheadline).pointSize
             case .footnote:
-                return 13
+                return UIFont.preferredFont(forTextStyle: .footnote).pointSize
             case .caption:
-                return 12
+                return UIFont.preferredFont(forTextStyle: .caption1).pointSize
             case .caption2:
-                return 11
+                return UIFont.preferredFont(forTextStyle: .caption2).pointSize
             @unknown default:
-                return 17
+                return UIFont.preferredFont(forTextStyle: .body).pointSize
             }
         }
     }

--- a/Sources/Compound/Form Styles/FormButtonStyle.swift
+++ b/Sources/Compound/Form Styles/FormButtonStyle.swift
@@ -70,7 +70,7 @@ public struct FormButtonStyle: PrimitiveButtonStyle {
             }
             .contentShape(Rectangle())
             .padding(FormRow.insets) // Re-apply the normal insets using padding.
-            .background(configuration.isPressed ? Color.compound.bgSubtlePrimary : .compound.bgCanvas)
+            .background(configuration.isPressed ? Color.compound.bgSubtlePrimary : .compound.bgCanvasDefault) // FIXME: Use elevation tokens.
         }
     }
 }

--- a/Sources/Compound/Form Styles/FormStyles.swift
+++ b/Sources/Compound/Form Styles/FormStyles.swift
@@ -31,7 +31,7 @@ public extension View {
     /// Styles a form section using the Compound design tokens.
     func compoundFormSection() -> some View {
         listRowInsets(FormRow.insets)
-            .listRowBackground(Color.compound.bgCanvas) // FIXME: Use elevation tokens.
+            .listRowBackground(Color.compound.bgCanvasDefault) // FIXME: Use elevation tokens.
     }
     
     /// Styles a form section footer using the Compound design tokens.

--- a/Sources/Compound/Icons/CompoundIcon.swift
+++ b/Sources/Compound/Icons/CompoundIcon.swift
@@ -1,0 +1,150 @@
+//
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import CompoundDesignTokens
+import SwiftUI
+
+/// A view that displays an icon from Compound. The icon behaves
+/// similarly to an SF Symbol whereby it will scale to match the font
+/// given to it by the `font` modifier, as well as with Dynamic Type.
+public struct CompoundIcon: View {
+    private var image: Image
+    
+    /// Creates an icon using a key path from the Compound tokens.
+    public init(_ icon: KeyPath<CompoundIcons, Image>) {
+        image = .compound[keyPath: icon]
+    }
+    
+    /// Creates an icon using a custom image for preview purposes
+    /// in the Inspector app.
+    ///
+    /// If using this initializer with any other image, make sure that its
+    /// dimensions match those of the compound icons otherwise it
+    /// will likely not behave as expected.
+    public init(customImage: Image) {
+        image = customImage
+    }
+    
+    public var body: some View {
+        image
+            .resizable()
+            .modifier(CompoundIconStyle())
+    }
+}
+
+/// A style that ensures the icon is rendered at the correct size, based upon
+/// its font.
+///
+/// This is a modifier to get access to the font from the environment as it
+/// doesn't appear to be available directly from the view as of iOS 16.4.
+private struct CompoundIconStyle: ViewModifier {
+    @Environment(\.font) private var font
+    
+    private var fontSize: FontSize {
+        FontSize.reflecting(font ?? .body) ?? .style(.body)
+    }
+    
+    func body(content: Content) -> some View {
+        let fontSize = fontSize
+        content
+            .modifier(CompoundIconFrame(fontSize: fontSize.value, textStyle: fontSize.style))
+    }
+}
+
+/// A simple modifier that applies a square frame of a given size that will be
+/// scaled dynamically based upon the specified text style.
+private struct CompoundIconFrame: ViewModifier {
+    @ScaledMetric private var size: CGFloat
+    
+    init(fontSize: CGFloat, textStyle: Font.TextStyle) {
+        _size = ScaledMetric(wrappedValue: fontSize, relativeTo: textStyle)
+    }
+    
+    func body(content: Content) -> some View {
+        content
+            .frame(width: size, height: size)
+    }
+}
+
+struct CompoundIcon_Previews: PreviewProvider {
+    static var previews: some View {
+        form
+            .previewLayout(.fixed(width: 375, height: 400))
+            .previewDisplayName("Form")
+        buttons
+            .padding(8)
+            .previewLayout(.sizeThatFits)
+            .previewDisplayName("Buttons")
+    }
+    
+    static var form: some View {
+        Form {
+            Section {
+                Label { Text("Plain Icon") } icon: {
+                    CompoundIcon(\.user)
+                        .foregroundColor(.compound.iconSecondary)
+                }
+                
+                Label { Text("Styled Icon") } icon: {
+                    CompoundIcon(\.user)
+                }
+                .labelStyle(.compoundFormRow(alignment: .center))
+                
+                Label("SF Symbol", systemImage: "person.crop.circle")
+                    .labelStyle(.compoundFormRow())
+            }
+            .compoundFormSection()
+        }
+        .compoundForm()
+        .safeAreaInset(edge: .bottom) {
+            Button { } label: {
+                Label { Text("Button") } icon: {
+                    CompoundIcon(\.user)
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .padding()
+        }
+    }
+    
+    static var buttons: some View {
+        VStack {
+            Button { } label: {
+                Label { Text("Heading Large") } icon: {
+                    CompoundIcon(\.user)
+                }
+            }
+            .font(.compound.headingLG)
+            .buttonStyle(.borderedProminent)
+            
+            Button { } label: {
+                Label { Text("Body Large") } icon: {
+                    CompoundIcon(\.user)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            
+            Button { } label: {
+                Label { Text("Body Small") } icon: {
+                    CompoundIcon(\.user)
+                }
+            }
+            .font(.compound.bodySM)
+            .buttonStyle(.borderedProminent)
+        }
+    }
+}

--- a/Sources/Compound/Icons/CompoundIcons.swift
+++ b/Sources/Compound/Icons/CompoundIcons.swift
@@ -1,0 +1,48 @@
+//
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import CompoundDesignTokens
+import SwiftUI
+
+public extension Image {
+    /// The icons used by Element as defined in Compound Design Tokens.
+    static let compound = CompoundIcons()
+}
+
+/// A manually generated collection of all the icons in Compound. This allows the
+/// `CompoundIcon` component to be created using a `KeyPath` until we can
+/// drop the static keyword in the generated tokens.
+public struct CompoundIcons {
+    /// The raw compound tokens.
+    private static let compound = CompoundLightDesignTokens.self
+    
+    public let webBrowser = compound.iconWebBrowser
+    public let visibilityVisible = compound.iconVisibilityVisible
+    public let visibilityInvisible = compound.iconVisibilityInvisible
+    public let user = compound.iconUser
+    public let thread = compound.iconThread
+    public let mobile = compound.iconMobile
+    public let lock = compound.iconLock
+    public let info = compound.iconInfo
+    public let error = compound.iconError
+    public let delete = compound.iconDelete
+    public let computer = compound.iconComputer
+    public let close = compound.iconClose
+    public let chevron = compound.iconChevron
+    public let check = compound.iconCheck
+    public let checkCircle = compound.iconCheckCircle
+    public let chat = compound.iconChat
+}

--- a/Tests/CompoundTests/CompoundTests.swift
+++ b/Tests/CompoundTests/CompoundTests.swift
@@ -1,8 +1,0 @@
-import XCTest
-@testable import Compound
-
-final class CompoundTests: XCTestCase {
-    func testExample() throws {
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-}

--- a/Tests/CompoundTests/FontSizeTests.swift
+++ b/Tests/CompoundTests/FontSizeTests.swift
@@ -1,0 +1,81 @@
+//
+// Copyright 2023 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+@testable import Compound
+import SwiftUI
+import XCTest
+
+final class FontSizeTests: XCTestCase {
+    func testTextStyle() throws {
+        let bodyFontSize = FontSize.reflecting(.body)
+        XCTAssertEqual(bodyFontSize?.value, 17)
+        XCTAssertEqual(bodyFontSize?.style, .body)
+        
+        let footnoteFontSize = FontSize.reflecting(.footnote)
+        XCTAssertEqual(footnoteFontSize?.value, 13)
+        XCTAssertEqual(footnoteFontSize?.style, .footnote)
+        
+        let largeTitleFontSize = FontSize.reflecting(.largeTitle)
+        XCTAssertEqual(largeTitleFontSize?.value, 34)
+        XCTAssertEqual(largeTitleFontSize?.style, .largeTitle)
+    }
+    
+    func testModifiedTextStyle() {
+        let boldCaptionFontSize = FontSize.reflecting(.caption.bold())
+        XCTAssertEqual(boldCaptionFontSize?.value, 12)
+        XCTAssertEqual(boldCaptionFontSize?.style, .caption)
+        
+        let styledTitle = Font.title.width(.compressed).bold().italic().monospaced()
+        let styledTitleFontSize = FontSize.reflecting(styledTitle)
+        XCTAssertEqual(styledTitleFontSize?.value, 28)
+        XCTAssertEqual(styledTitleFontSize?.style, .title)
+    }
+    
+    func testSystemFont() {
+        let system21FontSize = FontSize.reflecting(.system(size: 21))
+        XCTAssertEqual(system21FontSize?.value, 21)
+        
+        let boldSystem29FontSize = FontSize.reflecting(.system(size: 29).bold())
+        XCTAssertEqual(boldSystem29FontSize?.value, 29)
+        
+        let styledSystem33 = Font.system(size: 33).width(.compressed).bold().italic().monospacedDigit()
+        let styledSystem33FontSize = FontSize.reflecting(styledSystem33)
+        XCTAssertEqual(styledSystem33FontSize?.value, 33)
+    }
+    
+    func testCustomFont() {
+        let custom43FontSize = FontSize.reflecting(.custom("Baskerville", size: 43))
+        XCTAssertEqual(custom43FontSize?.value, 43)
+        XCTAssertEqual(custom43FontSize?.style, .body)
+        
+        let styledCustom35 = Font.custom("Baskerville", size: 35).weight(.thin).monospaced().italic()
+        let styledCustom35FontSize = FontSize.reflecting(styledCustom35)
+        XCTAssertEqual(styledCustom35FontSize?.value, 35)
+        XCTAssertEqual(styledCustom35FontSize?.style, .body)
+    }
+    
+    func testCustomFontWithTextStyle() {
+        let customTitle21FontSize = FontSize.reflecting(.custom("Baskerville", size: 21, relativeTo: .title))
+        XCTAssertEqual(customTitle21FontSize?.value, 21)
+        XCTAssertEqual(customTitle21FontSize?.style, .title)
+        
+        let styledCustomFootnote15 = Font.custom("Baskerville", size: 15, relativeTo: .footnote).weight(.thin).monospaced().italic()
+        let styledCustomFootnote15FontSize = FontSize.reflecting(styledCustomFootnote15)
+        XCTAssertEqual(styledCustomFootnote15FontSize?.value, 15)
+        XCTAssertEqual(styledCustomFootnote15FontSize?.style, .footnote)
+    }
+}

--- a/Tests/CompoundTests/FontSizeTests.swift
+++ b/Tests/CompoundTests/FontSizeTests.swift
@@ -20,14 +20,47 @@ import SwiftUI
 import XCTest
 
 final class FontSizeTests: XCTestCase {
+    /// Test all system text styles to assert mapping between `Font` and `UIFont`.
     func testTextStyle() throws {
-        let bodyFontSize = FontSize.reflecting(.body)
-        XCTAssertEqual(bodyFontSize?.value, 17)
-        XCTAssertEqual(bodyFontSize?.style, .body)
+        let caption2FontSize = FontSize.reflecting(.caption2)
+        XCTAssertEqual(caption2FontSize?.value, 11)
+        XCTAssertEqual(caption2FontSize?.style, .caption2)
+        
+        let captionFontSize = FontSize.reflecting(.caption)
+        XCTAssertEqual(captionFontSize?.value, 12)
+        XCTAssertEqual(captionFontSize?.style, .caption)
         
         let footnoteFontSize = FontSize.reflecting(.footnote)
         XCTAssertEqual(footnoteFontSize?.value, 13)
         XCTAssertEqual(footnoteFontSize?.style, .footnote)
+        
+        let subheadlineFontSize = FontSize.reflecting(.subheadline)
+        XCTAssertEqual(subheadlineFontSize?.value, 15)
+        XCTAssertEqual(subheadlineFontSize?.style, .subheadline)
+        
+        let calloutFontSize = FontSize.reflecting(.callout)
+        XCTAssertEqual(calloutFontSize?.value, 16)
+        XCTAssertEqual(calloutFontSize?.style, .callout)
+        
+        let bodyFontSize = FontSize.reflecting(.body)
+        XCTAssertEqual(bodyFontSize?.value, 17)
+        XCTAssertEqual(bodyFontSize?.style, .body)
+        
+        let headlineFontSize = FontSize.reflecting(.headline)
+        XCTAssertEqual(headlineFontSize?.value, 17)
+        XCTAssertEqual(headlineFontSize?.style, .headline)
+        
+        let title3FontSize = FontSize.reflecting(.title3)
+        XCTAssertEqual(title3FontSize?.value, 20)
+        XCTAssertEqual(title3FontSize?.style, .title3)
+        
+        let title2FontSize = FontSize.reflecting(.title2)
+        XCTAssertEqual(title2FontSize?.value, 22)
+        XCTAssertEqual(title2FontSize?.style, .title2)
+        
+        let titleFontSize = FontSize.reflecting(.title)
+        XCTAssertEqual(titleFontSize?.value, 28)
+        XCTAssertEqual(titleFontSize?.style, .title)
         
         let largeTitleFontSize = FontSize.reflecting(.largeTitle)
         XCTAssertEqual(largeTitleFontSize?.value, 34)


### PR DESCRIPTION
This PR makes the following changes:
- Adds a `CompoundIcon` component that works similarly to `Image(systemName:)` whereby it reads the current font size and scales with it appropriately.
- Adds a `CompoundIcons` struct that contains a manual mapping of all the tokens so we can use them via a `KeyPath` as the style dictionary is currently fixed to generate static properties (PR to fix this is [here](https://github.com/amzn/style-dictionary/pull/972)).
- Adds a dynamic type setting to the inspector when used on a Mac and adopts SwiftUI's new value based navigation so this is only applied to the detail view's contents.
- Updates to the latest revision of the tokens repo.