### PR TITLE
Keep navigation bar visible when searching in a modal.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -13,8 +13,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/SwiftUI-Introspect.git",
       "state" : {
-        "revision" : "c18951c747ab62af7c15e17a81bd37d4fd5a9979",
-        "version" : "0.2.3"
+        "revision" : "730ab9e6cdbb3122ad88277b295c4cecd284a311",
+        "version" : "0.9.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -10,13 +10,13 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vector-im/compound-design-tokens.git", revision: "cc950d575f8536ff5bebbd02e28c0b8ab541aa29"),
-        .package(url: "https://github.com/siteline/SwiftUI-Introspect.git", from: "0.2.3")
+        .package(url: "https://github.com/siteline/SwiftUI-Introspect.git", from: "0.9.0")
     ],
     targets: [
         .target(name: "Compound",
                 dependencies: [
                     .product(name: "CompoundDesignTokens", package: "compound-design-tokens"),
-                    .product(name: "Introspect", package: "SwiftUI-Introspect")
+                    .product(name: "SwiftUIIntrospect", package: "SwiftUI-Introspect")
                 ]),
         .testTarget(name: "CompoundTests", dependencies: ["Compound"])
     ]

--- a/Sources/Compound/Text Field Styles/SearchFieldStyle.swift
+++ b/Sources/Compound/Text Field Styles/SearchFieldStyle.swift
@@ -25,11 +25,6 @@ public extension View {
             // Uses the navigation stack as .searchField is unreliable when pushing the second search bar, during the create rooms flow.
             guard let searchController = navigationController.navigationBar.topItem?.searchController else { return }
             
-            // When the search field is part of a navigation bar on a modal, keep the whole bar visible when searching
-            if navigationController.presentingViewController != nil {
-                searchController.hidesNavigationBarDuringPresentation = false
-            }
-            
             // Ported from Riot iOS as this is the only reliable way to get the exact look we want.
             // However this is fragile and tied to gutwrenching the current UISearchBar internals.
             let textColor = UIColor(.compound.textPrimary)

--- a/Sources/Compound/Text Field Styles/SearchFieldStyle.swift
+++ b/Sources/Compound/Text Field Styles/SearchFieldStyle.swift
@@ -14,16 +14,24 @@
 // limitations under the License.
 //
 
-import Introspect
 import SwiftUI
+import SwiftUIIntrospect
 
 public extension View {
     /// Styles a search bar text field using the Compound design tokens.
     /// This modifier is to be used in combination with `.searchable`.
     func compoundSearchField() -> some View {
-        // Ported from Riot iOS as this is the only reliable way to get the exact look we want.
-        // However this is fragile and tied to gutwrenching the current UISearchBar internals.
-        introspectSearchController { searchController in
+        introspect(.navigationStack, on: .iOS(.v16), scope: .ancestor) { navigationController in
+            // Uses the navigation stack as .searchField is unreliable when pushing the second search bar, during the create rooms flow.
+            guard let searchController = navigationController.navigationBar.topItem?.searchController else { return }
+            
+            // When the search field is part of a navigation bar on a modal, keep the whole bar visible when searching
+            if navigationController.presentingViewController != nil {
+                searchController.hidesNavigationBarDuringPresentation = false
+            }
+            
+            // Ported from Riot iOS as this is the only reliable way to get the exact look we want.
+            // However this is fragile and tied to gutwrenching the current UISearchBar internals.
             let textColor = UIColor(.compound.textPrimary)
             let placeholderColor = UIColor(.compound.textPlaceholder)
             let textFieldTintColor = UIColor(.compound.iconAccentTertiary)


### PR DESCRIPTION
This PR updates Introspect to the latest version, uses the newer API (the previous ones have been deprecated, slated for removal in 1.0) and adds a change to `compoundSearchField()` that will keep the navigation bar visible during a search in a modal.