### PR TITLE
Fix row insets.

### DIFF
--- a/Inspector/Sources/Components/FormScreen.swift
+++ b/Inspector/Sources/Components/FormScreen.swift
@@ -85,7 +85,7 @@ struct FormScreen: View {
         }
         .labelStyle(.compoundFormRow())
         
-        Text("This is a row in the form, with a multiline description but it doesn't have either an icon or a title, just the this text here.")
+        Text("This is a row in the form, with a multiline description but it doesn't have either an icon or a title, just this text here.")
             .compoundFormSecondaryTextRow()
         
         TextField("Let us know",

--- a/Sources/Compound/Form Styles/FormRowLabelStyle.swift
+++ b/Sources/Compound/Form Styles/FormRowLabelStyle.swift
@@ -94,6 +94,7 @@ public struct FormRowLabelStyle: LabelStyle {
                         .foregroundColor(secondaryTextColor)
                 }
             }
+            .padding(.vertical, FormRow.verticalPadding)
         }
     }
 }

--- a/Sources/Compound/Form Styles/FormStyles.swift
+++ b/Sources/Compound/Form Styles/FormStyles.swift
@@ -18,13 +18,20 @@ import SwiftUI
 
 enum FormRow {
     /// Element specific insets that are used for all our Form rows.
-    static let insets = EdgeInsets(top: 7, leading: 16, bottom: 7, trailing: 16)
+    ///
+    /// The vertical insets are set to `0` to fix a bug with our desired padding when using a toggle with a
+    /// multiline label. This means that the `verticalPadding` property needs to be applied separately.
+    static let insets = EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
+    
+    /// The amount of padding between the top/bottom of the row and the row's label.
+    static let verticalPadding: CGFloat = 13
 }
 
 public extension View {
     /// Styles a form using the Compound design tokens.
     func compoundForm() -> some View {
-        scrollContentBackground(.hidden)
+        environment(\.defaultMinListRowHeight, 48)
+            .scrollContentBackground(.hidden)
             .background(Color.compound.bgSubtleSecondaryLevel0.ignoresSafeArea())
     }
     
@@ -39,6 +46,7 @@ public extension View {
     func compoundFormSecondaryTextRow() -> some View {
         font(.compound.bodyMD)
             .foregroundColor(.compound.textSecondary)
+            .padding(.vertical, FormRow.verticalPadding)
     }
     
     /// Styles a form section header using the Compound design tokens.


### PR DESCRIPTION
This PR matches the form row insets (and minimum row height) to the designs in Figma.

One issue that came up was `Toggle` and `Picker` would ignore the vertical insets at certain content sizes (I think there's some magic going on to allow the switch to escape the insets). To fix this, I've confirmed the desired behaviour with @janogarcia and the fix was to zero the vertical insets, replacing this with vertical padding on the label.