### PR TITLE
New avatar colors + tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Swift project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-swift
 
-name: Swift
+name: Tests
 
 on:
   pull_request:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+# This workflow will build a Swift project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-swift
+
+name: Swift
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run tests
+      run: swift test -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  tests:
 
     runs-on: macos-latest
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,5 +15,5 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run tests
-      run: xcodebuild test -scheme 'Compound' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14,OS=16'
+      run: xcodebuild test -scheme 'Compound' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14'
  

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run tests
-      run: swift test -v
+      run: xcodebuild test -scheme 'Compound' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.4'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   tests:
 
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,4 +15,5 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run tests
-      run: xcodebuild test -scheme 'Compound' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.4'
+      run: xcodebuild test -scheme 'Compound' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14,OS=16'
+ 

--- a/Sources/Compound/Colors/CompoundColors.swift
+++ b/Sources/Compound/Colors/CompoundColors.swift
@@ -92,6 +92,25 @@ public struct CompoundColors {
     public let bgSubtleSecondaryLevel0 = Color(UIColor { $0.isLight ? UIColor(compound.colorGray300) : UIColor(compound.colorThemeBg) })
     public let bgCanvasDefaultLevel1 = Color(UIColor { $0.isLight ? UIColor(compound.colorThemeBg) : UIColor(compound.colorGray300) })
     
+    // MARK: - Avatar Colors
+    // Used to determine the background color and the foreground color of an avatar.
+    
+    internal let avatarColors: [AvatarColor] = [
+        .init(background: compound.colorBlue300, foreground: compound.colorBlue1200),
+        .init(background: compound.colorFuchsia300, foreground: compound.colorFuchsia1200),
+        .init(background: compound.colorGreen300, foreground: compound.colorGreen1200),
+        .init(background: compound.colorPink300, foreground: compound.colorPink1200),
+        .init(background: compound.colorOrange300, foreground: compound.colorOrange1200),
+        .init(background: compound.colorCyan300, foreground: compound.colorCyan1200),
+        .init(background: compound.colorPurple300, foreground: compound.colorPurple1200),
+        .init(background: compound.colorLime300, foreground: compound.colorLime1200)
+    ]
+    
+    public func avatarColor(for contentId: String) -> AvatarColor {
+        let colorIndex = Int(contentId.hashCode % Int(avatarColors.count))
+        return avatarColors[colorIndex % avatarColors.count]
+    }
+    
     // MARK: - Awaiting Semantic Tokens
     
     /// This token is a placeholder and hasn't been finalised.
@@ -124,4 +143,25 @@ public struct CompoundColors {
 private extension UITraitCollection {
     /// Whether or not the trait collection contains a `userInterfaceStyle` of `.light`.
     var isLight: Bool { userInterfaceStyle == .light }
+}
+
+public struct AvatarColor: Equatable {
+    let background: Color
+    let foreground: Color
+    
+    fileprivate init(background: Color, foreground: Color) {
+        self.background = background
+        self.foreground = foreground
+    }
+}
+
+private extension String {
+    /// Calculates a numeric hash same as Element Web
+    /// See original function here https://github.com/matrix-org/matrix-react-sdk/blob/321dd49db4fbe360fc2ff109ac117305c955b061/src/utils/FormattingUtils.js#L47
+    var hashCode: Int {
+        let charCodeSum = self.reduce(0) { sum, char in
+            return sum + Int(char.unicodeScalars.first?.value ?? 0)
+        }
+        return (charCodeSum % Color.compound.avatarColors.count)
+    }
 }

--- a/Sources/Compound/Colors/CompoundColors.swift
+++ b/Sources/Compound/Colors/CompoundColors.swift
@@ -108,9 +108,8 @@ public struct CompoundColors {
         .init(background: compound.colorLime300, foreground: compound.colorLime1200)
     ]
     
-    public func avatarColor(for contentId: String) -> AvatarColor {
-        let colorIndex = Int(contentId.hashCode % Int(avatarColors.count))
-        return avatarColors[colorIndex % avatarColors.count]
+    public func avatarColor(for contentID: String) -> AvatarColor {
+        avatarColors[contentID.hashCode]
     }
     
     // MARK: - Awaiting Semantic Tokens
@@ -156,8 +155,8 @@ private extension String {
     /// Calculates a numeric hash same as Element Web
     /// See original function here https://github.com/matrix-org/matrix-react-sdk/blob/321dd49db4fbe360fc2ff109ac117305c955b061/src/utils/FormattingUtils.js#L47
     var hashCode: Int {
-        let charCodeSum = self.reduce(0) { sum, char in
-            return sum + Int(char.unicodeScalars.first?.value ?? 0)
+        let characterCodeSum = self.reduce(0) { sum, character in
+            sum + Int(char.unicodeScalars.first?.value ?? 0)
         }
         return (charCodeSum % Color.compound.avatarColors.count)
     }

--- a/Sources/Compound/Colors/CompoundColors.swift
+++ b/Sources/Compound/Colors/CompoundColors.swift
@@ -150,11 +150,6 @@ private extension UITraitCollection {
 public struct AvatarColor: Equatable {
     let background: Color
     let foreground: Color
-    
-    fileprivate init(background: Color, foreground: Color) {
-        self.background = background
-        self.foreground = foreground
-    }
 }
 
 private extension String {

--- a/Sources/Compound/Colors/CompoundColors.swift
+++ b/Sources/Compound/Colors/CompoundColors.swift
@@ -95,6 +95,8 @@ public struct CompoundColors {
     // MARK: - Avatar Colors
     // Used to determine the background color and the foreground color of an avatar.
     
+    // Order matches the one from web
+    // https://github.com/vector-im/compound-web/blob/5dda11aa9733462fb8422968181275bc3e9b35e3/src/components/Avatar/Avatar.module.css#L64
     internal let avatarColors: [AvatarColor] = [
         .init(background: compound.colorBlue300, foreground: compound.colorBlue1200),
         .init(background: compound.colorFuchsia300, foreground: compound.colorFuchsia1200),

--- a/Sources/Compound/Colors/CompoundColors.swift
+++ b/Sources/Compound/Colors/CompoundColors.swift
@@ -156,8 +156,8 @@ private extension String {
     /// See original function here https://github.com/matrix-org/matrix-react-sdk/blob/321dd49db4fbe360fc2ff109ac117305c955b061/src/utils/FormattingUtils.js#L47
     var hashCode: Int {
         let characterCodeSum = self.reduce(0) { sum, character in
-            sum + Int(char.unicodeScalars.first?.value ?? 0)
+            sum + Int(character.unicodeScalars.first?.value ?? 0)
         }
-        return (charCodeSum % Color.compound.avatarColors.count)
+        return (characterCodeSum % Color.compound.avatarColors.count)
     }
 }

--- a/Tests/CompoundTests/AvatarColorsTests.swift
+++ b/Tests/CompoundTests/AvatarColorsTests.swift
@@ -16,7 +16,7 @@ final class AvatarColorsTests: XCTestCase {
         let input: String
         private let webOutput: Int
         
-        // remember that web starts the index from 1 while we start from 0)
+        // remember that web starts the index from 1 while we start from 0
         var output: Int {
             webOutput - 1
         }

--- a/Tests/CompoundTests/AvatarColorsTests.swift
+++ b/Tests/CompoundTests/AvatarColorsTests.swift
@@ -1,0 +1,46 @@
+//
+//  File.swift
+//  
+//
+//  Created by Mauro Romito on 31/08/23.
+//
+
+import Foundation
+
+@testable import Compound
+import SwiftUI
+import XCTest
+
+final class AvatarColorsTests: XCTestCase {
+    struct TestCase {
+        let input: String
+        private let webOutput: Int
+        
+        // remember that web starts the index from 1 while we start from 0)
+        var output: Int {
+            webOutput - 1
+        }
+        
+        init(input: String, webOutput: Int) {
+            self.input = input
+            self.webOutput = webOutput
+        }
+    }
+    
+    func testAvatarColorHash() {
+        // Match the tests with the web ones for consistency between the two platforms
+        // https://github.com/vector-im/compound-web/blob/5dda11aa9733462fb8422968181275bc3e9b35e3/src/components/Avatar/Avatar.test.tsx#L62
+        let testCases: [TestCase] = [
+            .init(input: "@bob:example.org", webOutput: 8),
+            .init(input: "@alice:example.org", webOutput: 3),
+            .init(input: "@charlie:example.org", webOutput: 5),
+            .init(input: "@dan:example.org", webOutput: 8),
+            .init(input: "@elena:example.org", webOutput: 2),
+            .init(input: "@fanny:example.org", webOutput: 1)
+        ]
+        
+        for testCase in testCases {
+            XCTAssertEqual(Color.compound.avatarColor(for: testCase.input), Color.compound.avatarColors[testCase.output])
+        }
+    }
+}


### PR DESCRIPTION
In this PR I added the new avatar colors (which are now separated into background and foreground), improved the hashing function to match web, and included the same test that web uses to check the matching of the original string with the hashed color.

The PR also uses the same 8 colors as web, even if we are planning to only use 6 in the future.