### PR TITLE
Add CompoundIcon.Size.

### DIFF
--- a/Sources/Compound/Form Styles/FormButtonStyle.swift
+++ b/Sources/Compound/Form Styles/FormButtonStyle.swift
@@ -58,7 +58,6 @@ public enum FormRowAccessory: View {
         case .selected(let isSelected):
             if isSelected {
                 CompoundIcon(\.check)
-                    .font(.system(size: 24))
                     .foregroundColor(.compound.iconPrimary)
                     .accessibilityAddTraits(.isSelected)
             }

--- a/Sources/Compound/List/ListRowAccessory.swift
+++ b/Sources/Compound/List/ListRowAccessory.swift
@@ -27,12 +27,10 @@ public enum ListRowAccessory: View {
         switch self {
         case .navigationLink:
             CompoundIcon(\.chevronRight)
-                .font(.system(size: 24))
                 .foregroundColor(.compound.iconTertiaryAlpha)
                 .flipsForRightToLeftLayoutDirection(true)
         case .selected:
             CompoundIcon(\.check)
-                .font(.system(size: 24))
                 .foregroundColor(.compound.iconPrimary)
                 .accessibilityAddTraits(.isSelected)
                 .padding(.vertical, -4)


### PR DESCRIPTION
This PR stops using the font size to scale a Compound icon, instead adding a dedicated `Size` enum with the 3 pre-defined icon sizes.

Font styles are still used to determine rescaling with Dynamic Type.