### PR TITLE
Add iOS 17 window and navigationStack introspections.

### DIFF
--- a/Inspector/Inspector.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Inspector/Inspector.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -9,12 +9,39 @@
       }
     },
     {
+      "identity" : "prefire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/BarredEwe/Prefire",
+      "state" : {
+        "revision" : "898a4a9f5d5eb0a0b07adb1a7c89daf0f068b129",
+        "version" : "1.5.0"
+      }
+    },
+    {
       "identity" : "sfsafesymbols",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SFSafeSymbols/SFSafeSymbols.git",
       "state" : {
         "revision" : "7cca2d60925876b5953a2cf7341cd80fbeac983c",
         "version" : "4.1.1"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "696b86a6d151578bca7c1a2a3ed419a5f834d40f",
+        "version" : "1.13.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
+        "version" : "509.0.0"
       }
     },
     {

--- a/Inspector/Sources/CompoundInspectorApp.swift
+++ b/Inspector/Sources/CompoundInspectorApp.swift
@@ -35,7 +35,7 @@ struct CompoundInspectorApp: App {
             }
             .accentColor(.compound.textActionPrimary)
             .preferredColorScheme(preferredColorScheme)
-            .introspect(.window, on: .iOS(.v16)) { window in
+            .introspect(.window, on: .iOS(.v16, .v17)) { window in
                 // Apply the tint colour to alerts and confirmation dialogs
                 window.tintColor = .compound.textActionPrimary
             }

--- a/Inspector/Sources/System Components/ActionSheetScreen.swift
+++ b/Inspector/Sources/System Components/ActionSheetScreen.swift
@@ -44,7 +44,7 @@ struct ActionSheetScreen_Previews: PreviewProvider {
         NavigationStack {
             ActionSheetScreen()
         }
-        .introspect(.window, on: .iOS(.v16)) { window in
+        .introspect(.window, on: .iOS(.v16, .v17)) { window in
             // Fix the tint colour like the App strut does.
             window.tintColor = .compound.textActionPrimary
         }

--- a/Inspector/Sources/System Components/AlertScreen.swift
+++ b/Inspector/Sources/System Components/AlertScreen.swift
@@ -70,7 +70,7 @@ struct AlertScreen_Previews: PreviewProvider {
         NavigationStack {
             AlertScreen()
         }
-        .introspect(.window, on: .iOS(.v16)) { window in
+        .introspect(.window, on: .iOS(.v16, .v17)) { window in
             // Fix the tint colour like the App strut does.
             window.tintColor = .compound.textActionPrimary
         }

--- a/Sources/Compound/Text Field Styles/SearchFieldStyle.swift
+++ b/Sources/Compound/Text Field Styles/SearchFieldStyle.swift
@@ -21,7 +21,7 @@ public extension View {
     /// Styles a search bar text field using the Compound design tokens.
     /// This modifier is to be used in combination with `.searchable`.
     func compoundSearchField() -> some View {
-        introspect(.navigationStack, on: .iOS(.v16), scope: .ancestor) { navigationController in
+        introspect(.navigationStack, on: .iOS(.v16, .v17), scope: .ancestor) { navigationController in
             // Uses the navigation stack as .searchField is unreliable when pushing the second search bar, during the create rooms flow.
             guard let searchController = navigationController.navigationBar.topItem?.searchController else { return }
             


### PR DESCRIPTION
Turns out that `v17` is chosen when building with the iOS 16 SDK 🤦‍♂️

I've tested all of these and they behave as expected on the iOS 17 simulator when compiling with Xcode 14.3.