### PR TITLE
Remove playbook plugin from the target for now.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,9 +23,6 @@ let package = Package(
                 .product(name: "SwiftUIIntrospect", package: "SwiftUI-Introspect"),
                 .product(name: "SFSafeSymbols", package: "SFSafeSymbols"),
                 .product(name: "Prefire", package: "Prefire")
-            ],
-            plugins: [
-                .plugin(name: "PrefirePlaybookPlugin", package: "Prefire")
             ]
         ),
         .testTarget(


### PR DESCRIPTION
We haven't decided if we want this in Compound or EX yet, and it causes CI issues in places we probably shouldn't be blank enabling plugins to run.