### PR TITLE
Add CompoundButtonStyle from Element X

### DIFF
--- a/Inspector/Inspector.xcodeproj/project.pbxproj
+++ b/Inspector/Inspector.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		91B2EA9928CA05B900A90A83 /* Compound in Frameworks */ = {isa = PBXBuildFile; productRef = 91B2EA9828CA05B900A90A83 /* Compound */; };
 		91B2EA9C28CA064800A90A83 /* ColorsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B2EA9B28CA064800A90A83 /* ColorsScreen.swift */; };
 		91B946812A29062300F187EF /* IconsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91B946802A29062300F187EF /* IconsScreen.swift */; };
+		91CA00362AD7D83200121E0F /* ButtonsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917F562A28256DCD00D19543 /* ButtonsScreen.swift */; };
 		A75F953C2ACB0B31006C2657 /* PlatformViewVersionPredicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A75F953B2ACB0B31006C2657 /* PlatformViewVersionPredicate.swift */; };
 /* End PBXBuildFile section */
 
@@ -321,6 +322,7 @@
 				9132C6312A7280A500EAEF3D /* ContextMenuScreen.swift in Sources */,
 				9132C62F2A72785500EAEF3D /* AlertScreen.swift in Sources */,
 				917C22F429C3760A00B35660 /* FormScreen.swift in Sources */,
+				91CA00362AD7D83200121E0F /* ButtonsScreen.swift in Sources */,
 				91B2EA9C28CA064800A90A83 /* ColorsScreen.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Inspector/Sources/Components/ButtonsScreen.swift
+++ b/Inspector/Sources/Components/ButtonsScreen.swift
@@ -5,14 +5,13 @@
 //  Created by Doug on 06/05/2022.
 //
 
+import Compound
 import SwiftUI
-import DesignKit
 
 struct ButtonsScreen: View {
     var body: some View {
         ScreenContent(navigationTitle: "Buttons") {
-            PrimaryActionButtonStyle_Previews.states
-            SecondaryActionButtonStyle_Previews.states
+            CompoundButtonStyle_Previews.previews
         }
     }
 }

--- a/Sources/Compound/BaseStyles/CompoundButtonStyle.swift
+++ b/Sources/Compound/BaseStyles/CompoundButtonStyle.swift
@@ -1,0 +1,143 @@
+//
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Prefire
+import SwiftUI
+
+public extension ButtonStyle where Self == CompoundButtonStyle {
+    /// A button style that applies Compound design tokens to a button with various configuration options.
+    /// - Parameter kind: The kind of button being shown such as primary or secondary.
+    /// - Parameter size: The button size to use. Defaults to `large`.
+    static func compound(_ kind: Self.Kind, size: Self.Size = .large) -> CompoundButtonStyle {
+        CompoundButtonStyle(kind: kind, size: size)
+    }
+}
+
+/// Default button style for standalone buttons.
+public struct CompoundButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.colorScheme) private var colorScheme
+    
+    var kind: Kind
+    public enum Kind {
+        /// A filled button usually representing the default action.
+        case primary
+        /// A stroked button usually representing alternate actions.
+        case secondary
+    }
+    
+    var size: Size
+    public enum Size {
+        /// A button that is a regular size.
+        case medium
+        /// A button that is prominently sized.
+        case large
+    }
+    
+    private var horizontalPadding: CGFloat { size == .large ? 12 : 7 }
+    private var verticalPadding: CGFloat { size == .large ? 14 : 7 }
+    
+    public func makeBody(configuration: Self.Configuration) -> some View {
+        configuration.label
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, verticalPadding)
+            .frame(maxWidth: .infinity)
+            .font(.compound.bodyLGSemibold)
+            .foregroundColor(textColor(role: configuration.role))
+            .multilineTextAlignment(.center)
+            .background {
+                makeBackground(configuration: configuration)
+            }
+            .contentShape(Capsule())
+    }
+    
+    @ViewBuilder
+    private func makeBackground(configuration: Self.Configuration) -> some View {
+        if kind == .primary {
+            Capsule().fill(buttonColor(configuration: configuration))
+        } else {
+            Capsule().stroke(buttonColor(configuration: configuration))
+        }
+    }
+    
+    private func buttonColor(configuration: Self.Configuration) -> Color {
+        guard isEnabled else { return .compound.bgActionPrimaryDisabled }
+        if configuration.role == .destructive {
+            return .compound.bgCriticalPrimary.opacity(configuration.isPressed ? 0.6 : 1)
+        } else {
+            return configuration.isPressed ? .compound.bgActionPrimaryPressed : .compound.bgActionPrimaryRest
+        }
+    }
+    
+    private func textColor(role: ButtonRole?) -> Color {
+        if kind == .primary {
+            return .compound.textOnSolidPrimary
+        } else {
+            guard isEnabled else { return .compound.textDisabled }
+            return role == .destructive ? .compound.textCriticalPrimary : .compound.textActionPrimary
+        }
+    }
+}
+
+public struct CompoundButtonStyle_Previews: PreviewProvider, PrefireProvider {
+    public static var previews: some View {
+        ScrollView {
+            Section {
+                states(.large)
+                    .padding(.bottom, 40)
+            } header: {
+                Text("Large")
+                    .foregroundStyle(.compound.textSecondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.leading)
+            }
+            
+            Section {
+                states(.medium)
+            } header: {
+                Text("Medium")
+                    .foregroundStyle(.compound.textSecondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.leading)
+            }
+        }
+        .padding()
+    }
+    
+    public static func states(_ size: CompoundButtonStyle.Size) -> some View {
+        VStack {
+            Button("Primary") { /* preview */ }
+                .buttonStyle(.compound(.primary, size: size))
+            
+            Button("Destructive", role: .destructive) { /* preview */ }
+                .buttonStyle(.compound(.primary, size: size))
+            
+            Button("Disabled") { /* preview */ }
+                .buttonStyle(.compound(.primary, size: size))
+                .disabled(true)
+            
+            Button("Secondary") { /* preview */ }
+                .buttonStyle(.compound(.secondary, size: size))
+            
+            Button("Destructive", role: .destructive) { /* preview */ }
+                .buttonStyle(.compound(.secondary, size: size))
+            
+            Button("Disabled") { /* preview */ }
+                .buttonStyle(.compound(.secondary, size: size))
+                .disabled(true)
+        }
+    }
+}

--- a/Sources/Compound/BaseStyles/CompoundButtonStyle.swift
+++ b/Sources/Compound/BaseStyles/CompoundButtonStyle.swift
@@ -119,23 +119,23 @@ public struct CompoundButtonStyle_Previews: PreviewProvider, PrefireProvider {
     
     public static func states(_ size: CompoundButtonStyle.Size) -> some View {
         VStack {
-            Button("Primary") { /* preview */ }
+            Button("Primary") { }
                 .buttonStyle(.compound(.primary, size: size))
             
-            Button("Destructive", role: .destructive) { /* preview */ }
+            Button("Destructive", role: .destructive) { }
                 .buttonStyle(.compound(.primary, size: size))
             
-            Button("Disabled") { /* preview */ }
+            Button("Disabled") { }
                 .buttonStyle(.compound(.primary, size: size))
                 .disabled(true)
             
-            Button("Secondary") { /* preview */ }
+            Button("Secondary") { }
                 .buttonStyle(.compound(.secondary, size: size))
             
-            Button("Destructive", role: .destructive) { /* preview */ }
+            Button("Destructive", role: .destructive) { }
                 .buttonStyle(.compound(.secondary, size: size))
             
-            Button("Disabled") { /* preview */ }
+            Button("Disabled") { }
                 .buttonStyle(.compound(.secondary, size: size))
                 .disabled(true)
         }

--- a/Sources/Compound/Colors/CompoundColors.swift
+++ b/Sources/Compound/Colors/CompoundColors.swift
@@ -22,6 +22,11 @@ public extension Color {
     static let compound = CompoundColors()
 }
 
+public extension ShapeStyle where Self == Color {
+    /// The colours used by Element as defined in Compound Design Tokens.
+    static var compound: CompoundColors { Self.compound }
+}
+
 /// The colours used by Element as defined in Compound Design Tokens.
 /// This struct contains only the colour tokens in a more usable form.
 public struct CompoundColors {

--- a/Tests/CompoundTests/__Snapshots__/PreviewTests/test_compoundButtonStyle.1.png
+++ b/Tests/CompoundTests/__Snapshots__/PreviewTests/test_compoundButtonStyle.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:221fb718c94c32247fcd467afd30426d80eeaabb57cb3b537e576c2ea4648dae
-size 165526
+oid sha256:393428c82a87a0b5b2eff95176cfe977fcddb4b33f02e49300966a578d1a23c9
+size 155244

--- a/Tests/CompoundTests/__Snapshots__/PreviewTests/test_compoundButtonStyle.1.png
+++ b/Tests/CompoundTests/__Snapshots__/PreviewTests/test_compoundButtonStyle.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:221fb718c94c32247fcd467afd30426d80eeaabb57cb3b537e576c2ea4648dae
+size 165526


### PR DESCRIPTION
This PR merges `ElementActionButtonStyle` and `ElementCapsuleButtonStyle` from DesignKit into a single style.

There are no official button styles defined in Compound yet, however this follows Android for naming as we'll likely be aligned with that [component](https://www.figma.com/file/G1xy0HDZKJf5TCRFmKb5d5/Compound-Android-Components?type=design&node-id=854-64108&mode=dev).

There shouldn't be any visual difference between the at-rest implementations (but disabled and pressed states have been updated to use the respective colour tokens where available).