### PR TITLE
Move snapshots into submodule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-Tests/CompoundTests/__Snapshots__/** filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,10 @@ jobs:
     runs-on: macos-13
 
     steps:
-    - name: Checkout code
+    - name: Checkout code and snapshots
       uses: nschloe/action-cached-lfs-checkout@v1
+      with:
+        submodules: recursive
     
     - name: Run tests
       run: xcodebuild test -scheme 'Compound' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.4' -skipPackagePluginValidation

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Tests/CompoundTests/__Snapshots__"]
+	path = Tests/CompoundTests/__Snapshots__
+	url = git@github.com:vector-im/compound-ios-snapshots.git

--- a/Tests/CompoundTests/__Snapshots__/PreviewTests/test_compoundButtonStyle.1.png
+++ b/Tests/CompoundTests/__Snapshots__/PreviewTests/test_compoundButtonStyle.1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:393428c82a87a0b5b2eff95176cfe977fcddb4b33f02e49300966a578d1a23c9
-size 155244

--- a/Tests/CompoundTests/__Snapshots__/PreviewTests/test_compoundIcon.Accessibility-Icons-Only.png
+++ b/Tests/CompoundTests/__Snapshots__/PreviewTests/test_compoundIcon.Accessibility-Icons-Only.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3011f5531c83599c9d58d55a5bb0474b6136b8e907cb4ef98ed80de9adef26b8
-size 167251

--- a/Tests/CompoundTests/__Snapshots__/PreviewTests/test_compoundIcon.Accessibility-Labels.png
+++ b/Tests/CompoundTests/__Snapshots__/PreviewTests/test_compoundIcon.Accessibility-Labels.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:077eb3dce0e91742399d8877ca5e4cf40b2bc242e63fa35d0feeb561ff916cbd
-size 259274

--- a/Tests/CompoundTests/__Snapshots__/PreviewTests/test_compoundIcon.Buttons.png
+++ b/Tests/CompoundTests/__Snapshots__/PreviewTests/test_compoundIcon.Buttons.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:372bd1f003108245ed022eedc1a8b86cfdfdcb1ee146fbf3592aec33854efae4
-size 32478

--- a/Tests/CompoundTests/__Snapshots__/PreviewTests/test_compoundIcon.Form.png
+++ b/Tests/CompoundTests/__Snapshots__/PreviewTests/test_compoundIcon.Form.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0a50efc82d7971465a14056ae12821c3884764acb1759f71e1f6e0075d1e1086
-size 95871

--- a/Tests/CompoundTests/__Snapshots__/PreviewTests/test_compoundToggleStyle.1.png
+++ b/Tests/CompoundTests/__Snapshots__/PreviewTests/test_compoundToggleStyle.1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7d681e5774fc95f12a0ef7004310865c5e32dfa55e75e92177a127c85e8e49a
-size 90124

--- a/Tests/CompoundTests/__Snapshots__/PreviewTests/test_listDetailsLabel.1.png
+++ b/Tests/CompoundTests/__Snapshots__/PreviewTests/test_listDetailsLabel.1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:16738b243669892716c253e77f5e7f7bfe36281564d8920f0a7526cedae36c06
-size 75586

--- a/Tests/CompoundTests/__Snapshots__/PreviewTests/test_listInlinePicker.1.png
+++ b/Tests/CompoundTests/__Snapshots__/PreviewTests/test_listInlinePicker.1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9bb0fc12bc61cdd9088c758205312b46f23582418c1ce9b9dd1c6b5e615448e3
-size 91098

--- a/Tests/CompoundTests/__Snapshots__/PreviewTests/test_listLabel.1.png
+++ b/Tests/CompoundTests/__Snapshots__/PreviewTests/test_listLabel.1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9b25255a73267fed403d4a97694171f6f874e8fd88358e620f6e4ced6dd69890
-size 158279

--- a/Tests/CompoundTests/__Snapshots__/PreviewTests/test_listRow.1.png
+++ b/Tests/CompoundTests/__Snapshots__/PreviewTests/test_listRow.1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe882ca64c200e77dc2575f1b9ae36aa1ad73177cd243c5fc3ab4aa22e7fccde
-size 179711

--- a/Tests/CompoundTests/__Snapshots__/PreviewTests/test_listRowButtonStyle.1.png
+++ b/Tests/CompoundTests/__Snapshots__/PreviewTests/test_listRowButtonStyle.1.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9e2542c592b98782a6ea7420f053e24ac97e601a96f5e8519930fc15a5cf5aeb
-size 79758

--- a/Tests/CompoundTests/__Snapshots__/PreviewTests/test_listTextStyles.Form.png
+++ b/Tests/CompoundTests/__Snapshots__/PreviewTests/test_listTextStyles.Form.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce4967039db6c841629ff128f6ba53ee7586838744465cf42e61c1b993c7353b
-size 102408

--- a/Tests/CompoundTests/__Snapshots__/PreviewTests/test_listTextStyles.List.png
+++ b/Tests/CompoundTests/__Snapshots__/PreviewTests/test_listTextStyles.List.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:05e6fa8d36e9f24f0ad2d684747d6783a1e8645a6c4dda3dbae9093a063b97ae
-size 78978

--- a/Tests/CompoundTests/__Snapshots__/PreviewTests/test_searchStyle.Form.png
+++ b/Tests/CompoundTests/__Snapshots__/PreviewTests/test_searchStyle.Form.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7bfcd8ab6bc1d8b10705284a9a92ab6d5ae1eef6b279180e81d2b31873d253f9
-size 93032

--- a/Tests/CompoundTests/__Snapshots__/PreviewTests/test_searchStyle.List.png
+++ b/Tests/CompoundTests/__Snapshots__/PreviewTests/test_searchStyle.List.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:129e8006f9127c7f1d986da8892e1d2116c5fa5606d3f8af3a2328c848e6f4a8
-size 89632

--- a/Tests/PreviewTests.stencil
+++ b/Tests/PreviewTests.stencil
@@ -60,9 +60,7 @@ class PreviewTests: XCTestCase {
                                     file: file{% endif %},
                                     testName: testName)
 
-        if let failure,
-           !failure.contains("No reference was found on disk."),
-           !failure.contains("to test against the newly-recorded snapshot") {
+        if let failure {
             XCTFail(failure)
         }
 


### PR DESCRIPTION
This PR move the snapshots from LFS in this repo, into LFS inside of https://github.com/vector-im/compound-ios-snapshots that is added as a submodule. This fixes checkout errors when using the package inside of Xcode.