### PR TITLE
Switch submodule to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Tests/CompoundTests/__Snapshots__"]
 	path = Tests/CompoundTests/__Snapshots__
-	url = git@github.com:vector-im/compound-ios-snapshots.git
+	url = https://github.com/vector-im/compound-ios-snapshots.git


### PR DESCRIPTION
Turns out using ssh doesn't work on CI without more setup involved, this is probably better.