### PR TITLE
Add convenience initialisers for icons on ListRow.

### DIFF
--- a/Sources/Compound/List/ListDetailsLabel.swift
+++ b/Sources/Compound/List/ListDetailsLabel.swift
@@ -67,6 +67,12 @@ public struct ListDetailsLabel<Icon: View>: View {
     }
     
     public static func label(title: String,
+                             icon: KeyPath<CompoundIcons, Image>,
+                             isWaiting: Bool = false) -> Self where Icon == CompoundIcon {
+        ListDetailsLabel(title: title, icon: CompoundIcon(icon), isWaiting: isWaiting)
+    }
+    
+    public static func label(title: String,
                              systemIcon: SFSymbol,
                              isWaiting: Bool = false) -> Self where Icon == Image {
         ListDetailsLabel(title: title, icon: Image(systemSymbol: systemIcon), isWaiting: isWaiting)
@@ -74,6 +80,10 @@ public struct ListDetailsLabel<Icon: View>: View {
     
     public static func icon(_ icon: Icon, isWaiting: Bool = false) -> Self {
         ListDetailsLabel(icon: icon, isWaiting: isWaiting)
+    }
+    
+    public static func icon(_ icon: KeyPath<CompoundIcons, Image>, isWaiting: Bool = false) -> Self where Icon == CompoundIcon {
+        ListDetailsLabel(icon:CompoundIcon(icon), isWaiting: isWaiting)
     }
     
     public static func systemIcon(_ systemIcon: SFSymbol, isWaiting: Bool = false) -> Self where Icon == Image {

--- a/Sources/Compound/List/ListLabel.swift
+++ b/Sources/Compound/List/ListLabel.swift
@@ -145,10 +145,22 @@ public struct ListLabel<Icon: View>: View {
     }
     
     public static func `default`(title: String,
-                          description: String? = nil,
-                          systemIcon: SFSymbol,
-                          role: ButtonRole? = nil,
-                          iconAlignment: VerticalAlignment = .center) -> ListLabel where Icon == Image {
+                                 description: String? = nil,
+                                 icon: KeyPath<CompoundIcons, Image>,
+                                 role: ButtonRole? = nil,
+                                 iconAlignment: VerticalAlignment = .center) -> ListLabel where Icon == CompoundIcon {
+        .default(title: title,
+                 description: description,
+                 icon: CompoundIcon(icon),
+                 role: role,
+                 iconAlignment: iconAlignment)
+    }
+    
+    public static func `default`(title: String,
+                                 description: String? = nil,
+                                 systemIcon: SFSymbol,
+                                 role: ButtonRole? = nil,
+                                 iconAlignment: VerticalAlignment = .center) -> ListLabel where Icon == Image {
         .default(title: title,
                  description: description,
                  icon: Image(systemSymbol: systemIcon),
@@ -166,14 +178,20 @@ public struct ListLabel<Icon: View>: View {
     }
     
     public static func action(title: String,
-                       systemIcon: SFSymbol,
-                       role: ButtonRole? = nil) -> ListLabel where Icon == Image {
+                              icon: KeyPath<CompoundIcons, Image>,
+                              role: ButtonRole? = nil) -> ListLabel where Icon == CompoundIcon {
+        .action(title: title, icon: CompoundIcon(icon), role: role)
+    }
+    
+    public static func action(title: String,
+                              systemIcon: SFSymbol,
+                              role: ButtonRole? = nil) -> ListLabel where Icon == Image {
         .action(title: title, icon: Image(systemSymbol: systemIcon), role: role)
     }
     
     public static func centeredAction(title: String,
-                              icon: Icon,
-                              role: ButtonRole? = nil) -> ListLabel {
+                                      icon: Icon,
+                                      role: ButtonRole? = nil) -> ListLabel {
         ListLabel(title: title,
                   icon: icon,
                   role: role,
@@ -182,8 +200,14 @@ public struct ListLabel<Icon: View>: View {
     }
     
     public static func centeredAction(title: String,
-                               systemIcon: SFSymbol,
-                               role: ButtonRole? = nil) -> ListLabel where Icon == Image {
+                                      icon: KeyPath<CompoundIcons, Image>,
+                                      role: ButtonRole? = nil) -> ListLabel where Icon == CompoundIcon {
+        .centeredAction(title: title, icon: CompoundIcon(icon), role: role)
+    }
+    
+    public static func centeredAction(title: String,
+                                      systemIcon: SFSymbol,
+                                      role: ButtonRole? = nil) -> ListLabel where Icon == Image {
         .centeredAction(title: title, icon: Image(systemSymbol: systemIcon), role: role)
     }
     


### PR DESCRIPTION
Allows us to use

```swift
ListRow(label: .default(blah, icon: \.settings), …)
```

as a shortcut for

```swift
ListRow(label: .default(blah, icon: CompoundIcon(\.settings)), …)
```