### PR TITLE
Fix layout when changing selection in a list.

### DIFF
--- a/Sources/Compound/List/ListRow.swift
+++ b/Sources/Compound/List/ListRow.swift
@@ -97,7 +97,7 @@ public struct ListRow<Icon: View, DetailsIcon: View, CustomContent: View, Select
                              items: items)
         case .selection(let isSelected, let action):
             Button(action: action) {
-                RowContent(accessory: isSelected ? .selected : nil) { details } label: { label }
+                RowContent(accessory: isSelected ? .selected : .unselected) { details } label: { label }
             }
             // Add the following trait on iOS 17
             // .accessibilityAddTraits(.isToggle)

--- a/Sources/Compound/List/ListRowAccessory.swift
+++ b/Sources/Compound/List/ListRowAccessory.swift
@@ -20,8 +20,10 @@ import SwiftUI
 public enum ListRowAccessory: View {
     /// A chevron to indicate that the button pushes another screen.
     case navigationLink
-    /// A checkmark (when `true`) to indicate that the row is selected.
+    /// A checkmark to indicate that the row is selected.
     case selected
+    /// The same as ``selected`` but invisible to reserve space.
+    case unselected
     
     public var body: some View {
         switch self {
@@ -33,6 +35,10 @@ public enum ListRowAccessory: View {
             CompoundIcon(\.check)
                 .foregroundColor(.compound.iconPrimary)
                 .accessibilityAddTraits(.isSelected)
+                .padding(.vertical, -4)
+        case .unselected:
+            CompoundIcon(\.check)
+                .hidden()
                 .padding(.vertical, -4)
         }
     }


### PR DESCRIPTION
Make sure the checkmark space is reserved so that this doesn't happen:

https://github.com/vector-im/compound-ios/assets/6060466/f776a87b-0420-4fb7-a488-e4c66c691a71
