### PR TITLE
A couple of minor tweaks.

### DIFF
--- a/Sources/Compound/BaseStyles/CompoundTextFieldStyles.swift
+++ b/Sources/Compound/BaseStyles/CompoundTextFieldStyles.swift
@@ -1,0 +1,26 @@
+//
+// Copyright 2022 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Prefire
+import SwiftUI
+
+public extension Text {
+    /// Styles a text with the Compound design tokens to be displayed as a text field placeholder.
+    func compoundTextFieldPlaceholder() -> Text {
+        font(.compound.bodyLG)
+            .foregroundColor(.compound.textPlaceholder)
+    }
+}


### PR DESCRIPTION
- Fix the introspection of a text field in a list row (it was backed by a `UITextView` so was acting like a text editor by mistake)
- Add the toggle accessibility trait on iOS 17.
- Make the text field placeholder style reusable.